### PR TITLE
fit(release): update Copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2023 Dynamic Labs
+Copyright (c) 2024 Dynamic Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Release is failing because it updates the Copyright year and that breaks the release because it adds changes to git